### PR TITLE
Negate activation interaction fix

### DIFF
--- a/script/c24857466.lua
+++ b/script/c24857466.lua
@@ -54,7 +54,7 @@ function c24857466.initial_effect(c)
 end
 function c24857466.chop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if rp==tp then return end
+	if rp==tp or (not re:IsActiveType(TYPE_MONSTER) and not re:IsHasType(EFFECT_TYPE_ACTIVATE)) then return end
 	local de,dp=Duel.GetChainInfo(ev,CHAININFO_DISABLE_REASON,CHAININFO_DISABLE_PLAYER)
 	if de and dp==tp and de:GetHandler():IsType(TYPE_COUNTER) then
 		local ty=re:GetActiveType()

--- a/script/c63211608.lua
+++ b/script/c63211608.lua
@@ -32,7 +32,7 @@ function c63211608.chop1(e,tp,eg,ep,ev,re,r,rp)
 	e:GetLabelObject():SetLabel(0)
 end
 function c63211608.chop2(e,tp,eg,ep,ev,re,r,rp)
-	if rp==tp then return end
+	if rp==tp or (not re:IsActiveType(TYPE_MONSTER) and not re:IsHasType(EFFECT_TYPE_ACTIVATE)) then return end
 	local de,dp=Duel.GetChainInfo(ev,CHAININFO_DISABLE_REASON,CHAININFO_DISABLE_PLAYER)
 	if dp==tp then
 		e:SetLabel(1)


### PR DESCRIPTION
Van'Dalgyon the Dark Dragon Lord and Genex Ally Reliever should not trigger if negated a Spell/Trap effect