### PR TITLE
Magibullet ruling update

### DIFF
--- a/script/c31629407.lua
+++ b/script/c31629407.lua
@@ -37,7 +37,15 @@ function c31629407.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local rc=re:GetHandler()
 	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	return c:GetColumnGroup():IsContains(rc)
+	local p,loc,seq=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_SEQUENCE)
+	if bit.band(loc,LOCATION_SZONE)==0 or rc:IsControler(1-p) then
+		if rc:IsLocation(LOCATION_SZONE) and rc:IsControler(p) then
+			seq=rc:GetSequence()
+		else
+			seq=rc:GetPreviousSequence()
+		end
+	end
+	return c:IsColumn(seq,p,LOCATION_SZONE)
 end
 function c31629407.spfilter(c,e,tp)
 	return c:IsLevelBelow(4) and c:IsSetCard(0x108) and not c:IsCode(31629407) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)

--- a/script/c32841045.lua
+++ b/script/c32841045.lua
@@ -66,8 +66,16 @@ end
 function c32841045.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local rc=re:GetHandler()
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 or not c:GetColumnGroup():IsContains(rc) 
-		or not e:GetLabelObject():IsActivatable(tp) then return end
+	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 or not e:GetLabelObject():IsActivatable(tp) then return end
+	local p,loc,seq=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_SEQUENCE)
+	if bit.band(loc,LOCATION_SZONE)==0 or rc:IsControler(1-p) then
+		if rc:IsLocation(LOCATION_SZONE) and rc:IsControler(p) then
+			seq=rc:GetSequence()
+		else
+			seq=rc:GetPreviousSequence()
+		end
+	end
+	if not c:IsColumn(seq,p,LOCATION_SZONE) then return end
 	c:RegisterFlagEffect(32841046,RESET_EVENT+0x1fe0000+RESET_CHAIN,0,1)
 	if not SameColumnChain[e:GetLabelObject()] then
 		SameColumnChain[e:GetLabelObject()]=Group.CreateGroup()

--- a/script/c32841045.lua
+++ b/script/c32841045.lua
@@ -1,6 +1,5 @@
 --魔弾の射手 カスパール
 --Magibullet Shooter Caspar
---Scripted by Eerie Code
 function c32841045.initial_effect(c)
 	--activate from hand
 	local e1=Effect.CreateEffect(c)
@@ -22,37 +21,69 @@ function c32841045.initial_effect(c)
 	e0:SetOperation(aux.chainreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
-	e3:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e3:SetCode(EVENT_CHAIN_SOLVING)
 	e3:SetProperty(EFFECT_FLAG_DELAY)
 	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1,32841045)
-	e3:SetCondition(c32841045.thcon)
-	e3:SetTarget(c32841045.thtg)
-	e3:SetOperation(c32841045.thop)
+	e3:SetOperation(c32841045.regop)
 	c:RegisterEffect(e3)
+	local e4=Effect.CreateEffect(c)
+	e4:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e4:SetCode(EVENT_CUSTOM+32841045)
+	e4:SetProperty(EFFECT_FLAG_DELAY)
+	e4:SetCountLimit(1,32841045)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTarget(c32841045.thtg)
+	e4:SetOperation(c32841045.thop)
+	c:RegisterEffect(e4)
+	e3:SetLabelObject(e4)
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e5:SetCode(EVENT_ADJUST)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetOperation(c32841045.regop2)
+	e5:SetLabelObject(e4)
+	c:RegisterEffect(e5)
+	e4:SetLabelObject(e5)
+	if not SameColumnChain then SameColumnChain={} end
 end
-function c32841045.thcon(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local rc=re:GetHandler()
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	e:SetLabelObject(rc)
-	return c:GetColumnGroup():IsContains(rc)
-end
-function c32841045.thfilter(c,rc)
-	return c:IsSetCard(0x108) and not c:IsCode(rc:GetCode()) and c:IsAbleToHand()
+function c32841045.thfilter(c,g)
+	return c:IsSetCard(0x108) and c:IsAbleToHand() and not g:IsExists(Card.IsCode,1,nil,c:GetCode())
 end
 function c32841045.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local rc=re:GetHandler()
-	if chk==0 then return rc and Duel.IsExistingMatchingCard(c32841045.thfilter,tp,LOCATION_DECK,0,1,nil,rc) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function c32841045.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=Duel.SelectMatchingCard(tp,c32841045.thfilter,tp,LOCATION_DECK,0,1,1,nil,e:GetLabelObject())
+	local g=Duel.SelectMatchingCard(tp,c32841045.thfilter,tp,LOCATION_DECK,0,1,1,nil,eg)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c32841045.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local rc=re:GetHandler()
+	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 or not c:GetColumnGroup():IsContains(rc) 
+		or not e:GetLabelObject():IsActivatable(tp) then return end
+	c:RegisterFlagEffect(32841046,RESET_EVENT+0x1fe0000+RESET_CHAIN,0,1)
+	if not SameColumnChain[e:GetLabelObject()] then
+		SameColumnChain[e:GetLabelObject()]=Group.CreateGroup()
+		SameColumnChain[e:GetLabelObject()]:KeepAlive()
+	end
+	SameColumnChain[e:GetLabelObject()]:AddCard(rc)
+	e:GetLabelObject():GetLabelObject():SetLabel(1)
+end
+function c32841045.regop2(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local te=e:GetLabelObject()
+	if c:GetFlagEffect(32841046)==0 and e:GetLabel()==1 then
+		e:SetLabel(0)
+		if Duel.IsExistingMatchingCard(c32841045.thfilter,tp,LOCATION_DECK,0,1,nil,SameColumnChain[te]) and Duel.SelectEffectYesNo(tp,c) then
+			Duel.RaiseEvent(SameColumnChain[te],EVENT_CUSTOM+32841045,e,REASON_EFFECT,rp,ep,ev)
+		end
+		SameColumnChain[te]=nil
 	end
 end

--- a/script/c5230799.lua
+++ b/script/c5230799.lua
@@ -38,7 +38,15 @@ function c5230799.drcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local rc=re:GetHandler()
 	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	return c:GetColumnGroup():IsContains(rc)
+	local p,loc,seq=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_SEQUENCE)
+	if bit.band(loc,LOCATION_SZONE)==0 or rc:IsControler(1-p) then
+		if rc:IsLocation(LOCATION_SZONE) and rc:IsControler(p) then
+			seq=rc:GetSequence()
+		else
+			seq=rc:GetPreviousSequence()
+		end
+	end
+	return c:IsColumn(seq,p,LOCATION_SZONE)
 end
 function c5230799.cfilter(c)
 	return c:IsSetCard(0x108) and c:IsDiscardable()

--- a/script/c68024506.lua
+++ b/script/c68024506.lua
@@ -37,7 +37,15 @@ function c68024506.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local rc=re:GetHandler()
 	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	return c:GetColumnGroup():IsContains(rc)
+	local p,loc,seq=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_SEQUENCE)
+	if bit.band(loc,LOCATION_SZONE)==0 or rc:IsControler(1-p) then
+		if rc:IsLocation(LOCATION_SZONE) and rc:IsControler(p) then
+			seq=rc:GetSequence()
+		else
+			seq=rc:GetPreviousSequence()
+		end
+	end
+	return c:IsColumn(seq,p,LOCATION_SZONE)
 end
 function c68024506.filter(c,e,tp)
 	return c:IsSetCard(0x108) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)

--- a/script/c68246154.lua
+++ b/script/c68246154.lua
@@ -66,8 +66,16 @@ end
 function c68246154.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local rc=re:GetHandler()
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 or not c:GetColumnGroup():IsContains(rc) 
-		or not e:GetLabelObject():IsActivatable(tp) then return end
+	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 or not e:GetLabelObject():IsActivatable(tp) then return end
+	local p,loc,seq=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_SEQUENCE)
+	if bit.band(loc,LOCATION_SZONE)==0 or rc:IsControler(1-p) then
+		if rc:IsLocation(LOCATION_SZONE) and rc:IsControler(p) then
+			seq=rc:GetSequence()
+		else
+			seq=rc:GetPreviousSequence()
+		end
+	end
+	if not c:IsColumn(seq,p,LOCATION_SZONE) then return end
 	c:RegisterFlagEffect(68246155,RESET_EVENT+0x1fe0000+RESET_CHAIN,0,1)
 	if not SameColumnChain[e:GetLabelObject()] then
 		SameColumnChain[e:GetLabelObject()]=Group.CreateGroup()

--- a/script/c68246154.lua
+++ b/script/c68246154.lua
@@ -1,6 +1,5 @@
 --魔弾の射手 ドクトル
 --Magibullet Shooter Doctor
---Scripted by Eerie Code
 function c68246154.initial_effect(c)
 	--activate from hand
 	local e1=Effect.CreateEffect(c)
@@ -22,37 +21,69 @@ function c68246154.initial_effect(c)
 	e0:SetOperation(aux.chainreg)
 	c:RegisterEffect(e0)
 	local e3=Effect.CreateEffect(c)
-	e3:SetCategory(CATEGORY_TOHAND)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e3:SetCode(EVENT_CHAIN_SOLVING)
 	e3:SetProperty(EFFECT_FLAG_DELAY)
 	e3:SetRange(LOCATION_MZONE)
-	e3:SetCountLimit(1,68246154)
-	e3:SetCondition(c68246154.thcon)
-	e3:SetTarget(c68246154.thtg)
-	e3:SetOperation(c68246154.thop)
+	e3:SetOperation(c68246154.regop)
 	c:RegisterEffect(e3)
+	local e4=Effect.CreateEffect(c)
+	e4:SetCategory(CATEGORY_TOHAND)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e4:SetCode(EVENT_CUSTOM+68246154)
+	e4:SetProperty(EFFECT_FLAG_DELAY)
+	e4:SetCountLimit(1,68246154)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTarget(c68246154.thtg)
+	e4:SetOperation(c68246154.thop)
+	c:RegisterEffect(e4)
+	e3:SetLabelObject(e4)
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e5:SetCode(EVENT_ADJUST)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetOperation(c68246154.regop2)
+	e5:SetLabelObject(e4)
+	c:RegisterEffect(e5)
+	e4:SetLabelObject(e5)
+	if not SameColumnChain then SameColumnChain={} end
 end
-function c68246154.thcon(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	local rc=re:GetHandler()
-	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	e:SetLabelObject(rc)
-	return c:GetColumnGroup():IsContains(rc)
-end
-function c68246154.thfilter(c,rc)
-	return c:IsSetCard(0x108) and not c:IsCode(rc:GetCode()) and c:IsAbleToHand()
+function c68246154.thfilter(c,g)
+	return c:IsSetCard(0x108) and c:IsAbleToHand() and not g:IsExists(Card.IsCode,1,nil,c:GetCode())
 end
 function c68246154.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local rc=re:GetHandler()
-	if chk==0 then return rc and Duel.IsExistingMatchingCard(c68246154.thfilter,tp,LOCATION_GRAVE,0,1,nil,rc) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_GRAVE)
 end
 function c68246154.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=Duel.SelectMatchingCard(tp,c68246154.thfilter,tp,LOCATION_GRAVE,0,1,1,nil,e:GetLabelObject())
+	local g=Duel.SelectMatchingCard(tp,c68246154.thfilter,tp,LOCATION_GRAVE,0,1,1,nil,eg)
 	if g:GetCount()>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
 		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c68246154.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local rc=re:GetHandler()
+	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 or not c:GetColumnGroup():IsContains(rc) 
+		or not e:GetLabelObject():IsActivatable(tp) then return end
+	c:RegisterFlagEffect(68246155,RESET_EVENT+0x1fe0000+RESET_CHAIN,0,1)
+	if not SameColumnChain[e:GetLabelObject()] then
+		SameColumnChain[e:GetLabelObject()]=Group.CreateGroup()
+		SameColumnChain[e:GetLabelObject()]:KeepAlive()
+	end
+	SameColumnChain[e:GetLabelObject()]:AddCard(rc)
+	e:GetLabelObject():GetLabelObject():SetLabel(1)
+end
+function c68246154.regop2(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local te=e:GetLabelObject()
+	if c:GetFlagEffect(68246155)==0 and e:GetLabel()==1 then
+		e:SetLabel(0)
+		if Duel.IsExistingMatchingCard(c68246154.thfilter,tp,LOCATION_DECK,0,1,nil,SameColumnChain[te]) and Duel.SelectEffectYesNo(tp,c) then
+			Duel.RaiseEvent(SameColumnChain[te],EVENT_CUSTOM+68246154,e,REASON_EFFECT,rp,ep,ev)
+		end
+		SameColumnChain[te]=nil
 	end
 end

--- a/script/c94418111.lua
+++ b/script/c94418111.lua
@@ -37,7 +37,15 @@ function c94418111.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local rc=re:GetHandler()
 	if not re:IsHasType(EFFECT_TYPE_ACTIVATE) or c:GetFlagEffect(1)<=0 then return false end
-	return c:GetColumnGroup():IsContains(rc)
+	local p,loc,seq=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_SEQUENCE)
+	if bit.band(loc,LOCATION_SZONE)==0 or rc:IsControler(1-p) then
+		if rc:IsLocation(LOCATION_SZONE) and rc:IsControler(p) then
+			seq=rc:GetSequence()
+		else
+			seq=rc:GetPreviousSequence()
+		end
+	end
+	return c:IsColumn(seq,p,LOCATION_SZONE)
 end
 function c94418111.filter(c)
 	return c:IsSetCard(0x108) and c:IsAbleToDeck()

--- a/script/utility.lua
+++ b/script/utility.lua
@@ -60,6 +60,30 @@ function Card.RegisterEffect(c,e,forced,...)
 		c:RegisterEffect(e2)
 	end
 end
+function Card.IsColumn(c,seq,tp,loc)
+	if not c:IsOnField() then return false end
+	local cseq=c:GetSequence()
+	local seq=seq
+	local loc=loc and loc or c:GetLocation()
+	local tp=tp and tp or c:GetControler()
+	if c:IsLocation(LOCATION_MZONE) then
+		if cseq==5 then cseq=1 end
+		if cseq==6 then cseq=3 end
+	else
+		if cseq==6 then cseq=5 end
+	end
+	if loc==LOCATION_MZONE then
+		if seq==5 then seq=1 end
+		if seq==6 then seq=3 end
+	else
+		if cseq==6 then cseq=5 end
+	end
+	if c:IsControler(tp) then
+		return cseq==seq
+	else
+		return cseq==4-seq
+	end
+end
 
 function Auxiliary.Stringid(code,id)
 	return code*16+id


### PR DESCRIPTION
Magibullet Shooter Doctor&Shooter Caspar: Card to be added to hand must check all cards' names in the same chain in the same column

All Magibullets should check the column before the same column card leaves the field e.g. MST'd