### PR TITLE
Card Fixes

### DIFF
--- a/script/c101003019.lua
+++ b/script/c101003019.lua
@@ -32,22 +32,28 @@ function c101003019.hspcon(e,c)
 	local tp=c:GetControler()
 	local zone=0
 	local lg=Duel.GetMatchingGroup(c101003019.cfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
-    	for tc in aux.Next(lg) do
-        	if tp==tc:GetControler() then
-            		zone=bit.bor(zone,tc:GetColumnZone(LOCATION_MZONE))
-        	end
-    	end
+	for tc in aux.Next(lg) do
+    local z=tc:GetColumnZone(LOCATION_MZONE)
+    if tp==tc:GetControler() then
+		zone=bit.bor(zone,tc:GetColumnZone(LOCATION_MZONE))
+    else
+		zone=bit.bor(zone,bit.bor(bit.rshift(bit.band(z,0x1f0000),16),bit.lshift(bit.band(z,0x1f),16)))
+    end
+end
 	return Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_TOFIELD,zone)>0
 end
 function c101003019.hspval(e,c)
 	local tp=c:GetControler()
 	local zone=0
 	local lg=Duel.GetMatchingGroup(c101003019.cfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
-    	for tc in aux.Next(lg) do
-        	if tp==tc:GetControler() then
-            		zone=bit.bor(zone,tc:GetColumnZone(LOCATION_MZONE))
-        	end
-    	end
+	for tc in aux.Next(lg) do
+    local z=tc:GetColumnZone(LOCATION_MZONE)
+    if tp==tc:GetControler() then
+		zone=bit.bor(zone,tc:GetColumnZone(LOCATION_MZONE))
+    else
+		zone=bit.bor(zone,bit.bor(bit.rshift(bit.band(z,0x1f0000),16),bit.lshift(bit.band(z,0x1f),16)))
+    end
+end
 	return 0,zone
 end
 function c101003019.seqfilter(c)
@@ -64,13 +70,8 @@ function c101003019.seqop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) then return end
 	local seq=tc:GetSequence()
-	local flag=0
-	for i=0,4 do
-		if Duel.CheckLocation(tp,LOCATION_MZONE,i) then flag=bit.bor(flag,math.pow(2,i+16)) end
-	end
-	if flag==0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,571)
-	local s=Duel.SelectDisableField(tp,1,LOCATION_MZONE,0,flag)
+	local s=Duel.SelectDisableField(tp,1,LOCATION_MZONE,0,0)
 	local nseq=math.log(s,2)
 	Duel.MoveSequence(tc,nseq)
 end

--- a/script/c101003019.lua
+++ b/script/c101003019.lua
@@ -68,7 +68,7 @@ function c101003019.seqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c101003019.seqop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) then return end
+	if not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) or not (Duel.GetLocationCount(tp,LOCATION_MZONE)>0)then return end
 	local seq=tc:GetSequence()
 	Duel.Hint(HINT_SELECTMSG,tp,571)
 	local s=Duel.SelectDisableField(tp,1,LOCATION_MZONE,0,0)

--- a/script/c101003019.lua
+++ b/script/c101003019.lua
@@ -33,13 +33,13 @@ function c101003019.hspcon(e,c)
 	local zone=0
 	local lg=Duel.GetMatchingGroup(c101003019.cfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	for tc in aux.Next(lg) do
-    local z=tc:GetColumnZone(LOCATION_MZONE)
-    if tp==tc:GetControler() then
-		zone=bit.bor(zone,tc:GetColumnZone(LOCATION_MZONE))
-    else
-		zone=bit.bor(zone,bit.bor(bit.rshift(bit.band(z,0x1f0000),16),bit.lshift(bit.band(z,0x1f),16)))
-    end
-end
+		local z=tc:GetColumnZone(LOCATION_MZONE)
+		if tp==tc:GetControler() then
+			zone=bit.bor(zone,tc:GetColumnZone(LOCATION_MZONE))
+		else
+			zone=bit.bor(zone,bit.bor(bit.rshift(bit.band(z,0x1f0000),16),bit.lshift(bit.band(z,0x1f),16)))
+		end
+	end
 	return Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_TOFIELD,zone)>0
 end
 function c101003019.hspval(e,c)
@@ -47,13 +47,13 @@ function c101003019.hspval(e,c)
 	local zone=0
 	local lg=Duel.GetMatchingGroup(c101003019.cfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	for tc in aux.Next(lg) do
-    local z=tc:GetColumnZone(LOCATION_MZONE)
-    if tp==tc:GetControler() then
-		zone=bit.bor(zone,tc:GetColumnZone(LOCATION_MZONE))
-    else
-		zone=bit.bor(zone,bit.bor(bit.rshift(bit.band(z,0x1f0000),16),bit.lshift(bit.band(z,0x1f),16)))
-    end
-end
+		local z=tc:GetColumnZone(LOCATION_MZONE)
+		if tp==tc:GetControler() then
+			zone=bit.bor(zone,tc:GetColumnZone(LOCATION_MZONE))
+		else
+			zone=bit.bor(zone,bit.bor(bit.rshift(bit.band(z,0x1f0000),16),bit.lshift(bit.band(z,0x1f),16)))
+		end
+	end
 	return 0,zone
 end
 function c101003019.seqfilter(c)

--- a/script/c101003027.lua
+++ b/script/c101003027.lua
@@ -80,7 +80,7 @@ function c101003027.thop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c101003027.acop(e,tp,eg,ep,ev,re,r,rp)
 	if re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_SPELL) and e:GetHandler():GetFlagEffect(1)>0 then
-		e:GetHandler():AddCounter(0x1,1)
+		e:GetHandler():AddCounter(0x1,2)
 	end
 end
 function c101003027.incon(e)


### PR DESCRIPTION
3 distinct errors fixed. 
1. The card would summon itself to monster zones in the opposite column to that which had 2 cards in it, rather than the same column. Credit to andre for fixing this with some bit-shifting wizardry.
2. The card's second effect was a hard Once Per Turn, and could not be used in the same turn it was Special Summoned by its own effect. It has been corrected to a soft Once Per Turn to reflect the text, which also solves the conflict with the Special Summon's count limit.
3. When using the card's second effect, no zone would be offered by the game as a choice to move the target to, resulting in a soft lock. This seems to be the result of an attempt to filter for zones that are already occupied, but the Duel.SelectDisableField method already does this innately.