### PR TITLE
Cynet Backdoor ruling

### DIFF
--- a/script/c43839002.lua
+++ b/script/c43839002.lua
@@ -29,7 +29,7 @@ function c43839002.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c43839002.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT+REASON_TEMPORARY)>0 then
+	if tc and tc:IsRelateToEffect(e) and Duel.Remove(tc,tc:GetPosition(),REASON_EFFECT+REASON_TEMPORARY)>0 then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
@@ -39,6 +39,7 @@ function c43839002.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCondition(c43839002.retcon)
 		e1:SetOperation(c43839002.retop)
 		Duel.RegisterEffect(e1,tp)
+		if tc:IsPreviousPosition(POS_FACEDOWN) then return end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 		local g=Duel.SelectMatchingCard(tp,c43839002.thfilter,tp,LOCATION_DECK,0,1,1,nil,tc)
 		if g:GetCount()>0 then
@@ -52,7 +53,7 @@ function c43839002.retcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c43839002.retop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetLabelObject()
-	if Duel.ReturnToField(tc) then
+	if tc and Duel.ReturnToField(tc) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetDescription(aux.Stringid(43839002,0))


### PR DESCRIPTION
If target is flipped face-down, it gets banished face-down and you don't add a Cyberse monster to hand, rest of the effects continue applying as is